### PR TITLE
BugFix: Split create panic when container name length is less than 12 

### DIFF
--- a/cds-tool/src/docker.rs
+++ b/cds-tool/src/docker.rs
@@ -46,7 +46,7 @@ pub fn get_container_id(id_name: &str) -> Result<Option<String>> {
 
         let (id, name) = (line[0], line[1]);
 
-        if id.starts_with(id_name.split_at(12).0) || name.starts_with(id_name) {
+        if id.starts_with(id_name) || name.starts_with(id_name) {
             return Ok(Some(id.to_owned()));
         }
     }


### PR DESCRIPTION
If container name length is less than 12 char (ex: test) it panics for index out of bounds